### PR TITLE
[Hotfix] Fix Target Direction In Move Backward and Forward

### DIFF
--- a/src/suiryoku/locomotion/process/locomotion.cpp
+++ b/src/suiryoku/locomotion/process/locomotion.cpp
@@ -257,7 +257,7 @@ void Locomotion::move_backward(const keisan::Angle<double> & direction)
   double x_speed = 0.0;
   double a_speed = keisan::map(delta_direction, -min_delta_direction, min_delta_direction, backward_max_a, -backward_max_a);
   if (std::abs(delta_direction) > 15.0) {
-    a_speed = (delta_direction < 0.0) ? backward_max_a : -backward_max_a;
+    a_speed = (delta_direction < 0.0) ? -backward_max_a : backward_max_a;
   } else {
     x_speed = keisan::map(std::abs(delta_direction), 0.0, 15.0, backward_max_x, backward_min_x);
   }
@@ -277,18 +277,17 @@ bool Locomotion::move_backward_to(const keisan::Point2 & target)
   double target_distance = std::hypot(delta_x, delta_y);
 
   if (target_distance < 8.0) {
-    walk_in_position();
     return true;
   }
 
-  auto direction = keisan::signed_arctan(delta_y, delta_x) + 180.0_deg;
+  auto direction = keisan::signed_arctan(delta_y, delta_x).normalize();
   auto delta_direction = (direction - robot->orientation).normalize().degree();
 
   double x_speed = keisan::map(std::abs(delta_direction), 0.0, 15.0, backward_max_x, backward_min_x);
 
   double a_speed = keisan::map(delta_direction, -25.0, 25.0, backward_max_a, -backward_max_a);
   if (std::abs(delta_direction) > 15.0) {
-    a_speed = (delta_direction < 0.0) ? backward_max_a : -backward_max_a;
+    a_speed = (delta_direction < 0.0) ? -backward_max_a : backward_max_a;
     x_speed = keisan::map(std::abs(a_speed), 0.0, backward_max_a, backward_max_a, 0.0);
   }
 
@@ -333,7 +332,7 @@ bool Locomotion::move_forward_to(const keisan::Point2 & target)
     return true;
   }
   
-  auto direction = keisan::signed_arctan(delta_y, delta_x);
+  auto direction = keisan::signed_arctan(delta_y, delta_x).normalize();
   double delta_direction = (direction - robot->orientation).normalize().degree();
 
   double x_speed = keisan::map(std::abs(delta_direction), 0.0, 15.0, move_max_x, move_min_x);


### PR DESCRIPTION
## Jira Link: 

## Description

fix the target direction of `move_to_forward()`, `move_to_backward()`, and `move_backward()`.  

## Type of Change

- [X] Bugfix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [X] Manual tested.

## Checklist:

- [X] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.