### PR TITLE
[Hotfix] - Remove Inverse A Move

### DIFF
--- a/include/suiryoku/locomotion/model/robot.hpp
+++ b/include/suiryoku/locomotion/model/robot.hpp
@@ -57,7 +57,6 @@ public:
   double y_speed;
   double a_speed;
   bool aim_on;
-  bool inverse_a_move;
 };
 
 }  // namespace suiryoku

--- a/include/suiryoku/locomotion/process/locomotion.hpp
+++ b/include/suiryoku/locomotion/process/locomotion.hpp
@@ -59,7 +59,7 @@ public:
 
   bool dribble(const keisan::Angle<double> & direction);
   bool pivot(const keisan::Angle<double> & direction);
-  bool pivot_inverse_a_move(const keisan::Angle<double> & direction);
+  bool pivot_new(const keisan::Angle<double> & direction);
 
   bool position_until(
     const keisan::Angle<double> & target_pan,

--- a/src/suiryoku/locomotion/node/locomotion_node.cpp
+++ b/src/suiryoku/locomotion/node/locomotion_node.cpp
@@ -95,7 +95,6 @@ void LocomotionNode::publish_walking()
   walking_msg.y_move = robot->y_speed;
   walking_msg.a_move = robot->a_speed;
   walking_msg.aim_on = robot->aim_on;
-  walking_msg.inverse_a_move = robot->inverse_a_move;
 
   set_walking_publisher->publish(walking_msg);
 }

--- a/src/suiryoku/locomotion/process/locomotion.cpp
+++ b/src/suiryoku/locomotion/process/locomotion.cpp
@@ -615,7 +615,7 @@ bool Locomotion::pivot(const keisan::Angle<double> & direction)
   return false;
 }
 
-bool Locomotion::pivot_inverse_a_move(const keisan::Angle<double> & direction)
+bool Locomotion::pivot_new(const keisan::Angle<double> & direction)
 {
   if (initial_pivot) {
     initial_pivot = false;
@@ -627,13 +627,12 @@ bool Locomotion::pivot_inverse_a_move(const keisan::Angle<double> & direction)
 
   if (std::abs(delta_direction) < pivot_max_delta_direction) {
     walk_in_position();
-    robot->inverse_a_move = false;
     return true;
   }
 
   double delta_tilt = (pivot_target_tilt - robot->tilt + robot->tilt_center).degree();
 
-  printf("pivot inverse a move\n");
+  printf("pivot new\n");
   printf("delta direction %f\n", delta_direction);
   printf("delta tilt %f\n", delta_tilt);
 
@@ -662,7 +661,7 @@ bool Locomotion::pivot_inverse_a_move(const keisan::Angle<double> & direction)
   x_speed = keisan::smooth(robot->x_speed, x_speed, smooth_ratio);
   y_speed = keisan::smooth(robot->y_speed, y_speed, smooth_ratio);
 
-  robot->inverse_a_move = true;
+  robot->aim_on = true;
   robot->x_speed = x_speed;
   robot->y_speed = y_speed;
   robot->a_speed = a_speed;


### PR DESCRIPTION
## Jira Link: 

## Description

```inverse_a_move``` serves the same functionality as ```aim_on```, therefore it is redundant.

## Type of Change

- [x] Bugfix
- [ ] Enhancement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [ ] Manual tested.

## Checklist:

- [x] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.