### PR TITLE
[Hotfix] change using topic name directly on locomotion node

### DIFF
--- a/src/suiryoku/locomotion/node/locomotion_node.cpp
+++ b/src/suiryoku/locomotion/node/locomotion_node.cpp
@@ -43,20 +43,20 @@ LocomotionNode::LocomotionNode(
 : locomotion(locomotion), robot(locomotion->get_robot()), walking_state(false), set_odometry(false)
 {
   set_walking_publisher = node->create_publisher<SetWalking>(
-    aruku::WalkingNode::set_walking_topic(), 10);
+    "walking/set_walking", 10);
 
   measurement_status_subscriber = node->create_subscription<MeasurementStatus>(
-    kansei::measurement::MeasurementNode::status_topic(), 10,
+    "measurement/status", 10,
     [this](const MeasurementStatus::SharedPtr message) {
       this->robot->is_calibrated = message->is_calibrated;
       this->robot->orientation = keisan::make_degree(message->orientation.yaw);
     });
 
   set_odometry_publisher = node->create_publisher<Point2>(
-    aruku::WalkingNode::set_odometry_topic(), 10);
+    "walking/set_odometry", 10);
 
   walking_status_subscriber = node->create_subscription<WalkingStatus>(
-    aruku::WalkingNode::status_topic(), 10,
+    "walking/status", 10,
     [this](const WalkingStatus::SharedPtr message)
     {
       this->robot->is_walking = message->is_running;


### PR DESCRIPTION
## Jira Link: 

## Description

change using the topic name directly on the locomotion node instead of using a function like status_topic.

## Type of Change

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [x] Manual tested.

## Checklist:

- [x] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.