### PR TITLE
[Feature] Add config for half pivot

### DIFF
--- a/include/suiryoku/locomotion/process/locomotion.hpp
+++ b/include/suiryoku/locomotion/process/locomotion.hpp
@@ -87,6 +87,7 @@ public:
   std::string config_name;
 
   bool initial_pivot;
+  keisan::Angle<double> pivot_stop_limit;
 
 private:
 

--- a/src/suiryoku/locomotion/process/locomotion.cpp
+++ b/src/suiryoku/locomotion/process/locomotion.cpp
@@ -170,6 +170,7 @@ void Locomotion::set_config(const nlohmann::json & json)
     bool valid_section = true;
 
     double pivot_target_tilt_double;
+    double pivot_stop_limit_double;
 
     valid_section &= jitsuyo::assign_val(pivot_section, "min_x", pivot_min_x);
     valid_section &= jitsuyo::assign_val(pivot_section, "max_x", pivot_max_x);
@@ -179,8 +180,10 @@ void Locomotion::set_config(const nlohmann::json & json)
     valid_section &= jitsuyo::assign_val(pivot_section, "max_delta_direction", pivot_max_delta_direction);
     valid_section &= jitsuyo::assign_val(pivot_section, "pan_range_a_speed", pivot_pan_range_a_speed);
     valid_section &= jitsuyo::assign_val(pivot_section, "target_tilt", pivot_target_tilt_double);
+    valid_section &= jitsuyo::assign_val(pivot_section, "pivot_stop_limit", pivot_stop_limit_double);
     
     pivot_target_tilt = keisan::make_degree(pivot_target_tilt_double);
+    pivot_stop_limit = keisan::make_degree(pivot_stop_limit_double);
 
     if (!valid_section) {
       std::cout << "Error found at section `pivot`" << std::endl;


### PR DESCRIPTION
## Jira Link: 

## Description

Add new configuration in locomotion to determine the limit of half pivot. This PR is in accordance with
[[Feature] Stop pivoting at 90 degrees for a faster kick #30](https://github.com/ichiro-its/soccer/pull/30)
[[Feature] Add 90 degrees sidekick action #51](https://github.com/ichiro-its/akushon/pull/51)

## Type of Change

- [ ] Bugfix
- [ ] Enhancement
- [X] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [X] Manual tested.

## Checklist:

- [X] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.