### PR TITLE
[PI Sprint 25/26] - [Enhancement] Fused Robot Position MCL 

### DIFF
--- a/include/suiryoku/locomotion/model/robot.hpp
+++ b/include/suiryoku/locomotion/model/robot.hpp
@@ -40,6 +40,7 @@ public:
   bool is_calibrated;
   keisan::Angle<double> orientation;
   keisan::Point2 position;
+  keisan::Point2 fused_position;
 
   bool is_walking;
 

--- a/include/suiryoku/locomotion/node/locomotion_node.hpp
+++ b/include/suiryoku/locomotion/node/locomotion_node.hpp
@@ -69,6 +69,8 @@ private:
 
   rclcpp::Subscription<Head>::SharedPtr head_subscriber;
 
+  rclcpp::Subscription<Point2>::SharedPtr fused_position_subscriber;
+
   std::shared_ptr<Locomotion> locomotion;
   std::shared_ptr<Robot> robot;
 

--- a/include/suiryoku/locomotion/process/locomotion.hpp
+++ b/include/suiryoku/locomotion/process/locomotion.hpp
@@ -43,12 +43,12 @@ public:
   bool walk_in_position_until_stop();
 
   void move_backward(const keisan::Angle<double> & direction);
-  bool move_backward_to(const keisan::Point2 & target);
+  bool move_backward_to(const keisan::Point2 & target, double stop_distance = 8.0);
 
   void move_forward(const keisan::Angle<double> & direction);
-  bool move_forward_to(const keisan::Point2 & target);
+  bool move_forward_to(const keisan::Point2 & target, double stop_distance = 8.0);
 
-  bool move_to_left_and_right(const keisan::Point2 & target);
+  bool move_to_left_and_right(const keisan::Point2 & target, double stop_distance = 5.0);
   void move_left(const keisan::Angle<double> & direction);
   void move_right(const keisan::Angle<double> & direction);
 

--- a/include/suiryoku/locomotion/process/locomotion.hpp
+++ b/include/suiryoku/locomotion/process/locomotion.hpp
@@ -99,6 +99,8 @@ public:
   std::function<void()> stop;
   std::function<void()> start;
 
+  std::function<keisan::Point2()> get_robot_position;
+
   std::string config_name;
 
   bool initial_pivot;

--- a/src/suiryoku/locomotion/node/locomotion_node.cpp
+++ b/src/suiryoku/locomotion/node/locomotion_node.cpp
@@ -67,6 +67,13 @@ LocomotionNode::LocomotionNode(
       this->robot->position.y = message->odometry.y;
     });
 
+  fused_position_subscriber = node->create_subscription<Point2>(
+    "/localization/fused_position", 10,
+    [this](const Point2::SharedPtr message) {
+      this->robot->fused_position.x = message->x;
+      this->robot->fused_position.y = message->y;
+    });
+
   head_subscriber = node->create_subscription<Head>(
     "/head/set_head_data", 10,
     [this](const Head::SharedPtr message) {

--- a/src/suiryoku/locomotion/node/locomotion_node.cpp
+++ b/src/suiryoku/locomotion/node/locomotion_node.cpp
@@ -68,7 +68,7 @@ LocomotionNode::LocomotionNode(
     });
 
   fused_position_subscriber = node->create_subscription<Point2>(
-    "/localization/fused_position", 10,
+    "/localization/fused_pose", 10,
     [this](const Point2::SharedPtr message) {
       this->robot->fused_position.x = message->x;
       this->robot->fused_position.y = message->y;

--- a/src/suiryoku/locomotion/process/locomotion.cpp
+++ b/src/suiryoku/locomotion/process/locomotion.cpp
@@ -404,8 +404,8 @@ void Locomotion::move_backward(const keisan::Angle<double> & direction)
 
 bool Locomotion::move_backward_to(const keisan::Point2 & target)
 {
-  double delta_x = (robot->position.x - target.x);
-  double delta_y = (robot->position.y - target.y);
+  double delta_x = (get_robot_position().x - target.x);
+  double delta_y = (get_robot_position().y - target.y);
 
   double target_distance = std::hypot(delta_x, delta_y);
 
@@ -457,8 +457,8 @@ void Locomotion::move_forward(const keisan::Angle<double> & direction)
 
 bool Locomotion::move_forward_to(const keisan::Point2 & target)
 {
-  double delta_x = (target.x - robot->position.x);
-  double delta_y = (target.y - robot->position.y);
+  double delta_x = (target.x - get_robot_position().x);
+  double delta_y = (target.y - get_robot_position().y);
 
   double target_distance = std::hypot(delta_x, delta_y);
 
@@ -493,8 +493,8 @@ bool Locomotion::move_forward_to(const keisan::Point2 & target)
 
 bool Locomotion::move_to_left_and_right(const keisan::Point2 & target)
 {
-  double delta_x = target.x - robot->position.x;
-  double delta_y = std::abs(target.y) - robot->position.y;
+  double delta_x = target.x - get_robot_position().x;
+  double delta_y = std::abs(target.y) - get_robot_position().y;
 
   double target_distance = std::hypot(delta_x, delta_y);
 

--- a/src/suiryoku/locomotion/process/locomotion.cpp
+++ b/src/suiryoku/locomotion/process/locomotion.cpp
@@ -402,14 +402,14 @@ void Locomotion::move_backward(const keisan::Angle<double> & direction)
   start();
 }
 
-bool Locomotion::move_backward_to(const keisan::Point2 & target)
+bool Locomotion::move_backward_to(const keisan::Point2 & target, double stop_distance)
 {
   double delta_x = (get_robot_position().x - target.x);
   double delta_y = (get_robot_position().y - target.y);
 
   double target_distance = std::hypot(delta_x, delta_y);
 
-  if (target_distance < 8.0) {
+  if (target_distance < stop_distance) {
     return true;
   }
 
@@ -455,14 +455,14 @@ void Locomotion::move_forward(const keisan::Angle<double> & direction)
   start();
 }
 
-bool Locomotion::move_forward_to(const keisan::Point2 & target)
+bool Locomotion::move_forward_to(const keisan::Point2 & target, double stop_distance)
 {
   double delta_x = (target.x - get_robot_position().x);
   double delta_y = (target.y - get_robot_position().y);
 
   double target_distance = std::hypot(delta_x, delta_y);
 
-  if (target_distance < 8.0) {
+  if (target_distance < stop_distance) {
     return true;
   }
 
@@ -491,14 +491,14 @@ bool Locomotion::move_forward_to(const keisan::Point2 & target)
   return false;
 }
 
-bool Locomotion::move_to_left_and_right(const keisan::Point2 & target)
+bool Locomotion::move_to_left_and_right(const keisan::Point2 & target, double stop_distance)
 {
   double delta_x = target.x - get_robot_position().x;
   double delta_y = std::abs(target.y) - get_robot_position().y;
 
   double target_distance = std::hypot(delta_x, delta_y);
 
-  if (target_distance < 5.0) {
+  if (target_distance < stop_distance) {
     return true;
   }
 


### PR DESCRIPTION
## Jira Link: 

## Description

Subscribe to the `/localization/fused_pose topic`. Replace `robot->position` in the locomotion with `get_robot_position()`, so that soccer package can choose between using localization or odometry from configuration.

## Type of Change

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [x] Manual tested.

## Checklist:

- [x] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.