### PR TITLE
[Enhancement] Store Previous Robot IMU

### DIFF
--- a/include/suiryoku/locomotion/model/robot.hpp
+++ b/include/suiryoku/locomotion/model/robot.hpp
@@ -36,9 +36,17 @@ public:
   keisan::Angle<double> get_pan() const;
   keisan::Angle<double> get_tilt() const;
 
+  void set_orientation(const keisan::Point3 & orientation);
+
   // member for getting
   bool is_calibrated;
   keisan::Angle<double> orientation;
+  keisan::Angle<double> imu_roll;
+  keisan::Angle<double> imu_pitch;
+
+  keisan::Angle<double> prev_imu_roll;
+  keisan::Angle<double> prev_imu_pitch;
+
   keisan::Point2 position;
   keisan::Point2 fused_position;
 

--- a/include/suiryoku/locomotion/process/locomotion.hpp
+++ b/include/suiryoku/locomotion/process/locomotion.hpp
@@ -75,7 +75,7 @@ public:
   bool move_skew(const keisan::Angle<double> & direction);
   bool move_skew(const keisan::Angle<double> & direction, bool skew_left);
 
-  bool dribble(const keisan::Angle<double> & direction);
+  bool dribble(const keisan::Angle<double> & direction, bool in_dribble_range = false);
   bool pivot(const keisan::Angle<double> & direction);
   bool pivot_new(const keisan::Angle<double> & direction);
 
@@ -91,7 +91,7 @@ public:
   bool position_kick_general(const keisan::Angle<double> & direction);
   bool position_kick_range_pan_tilt(
     const keisan::Angle<double> & direction, bool precise_kick, bool left_kick,
-    bool is_positioning_center);
+    bool is_positioning_center, bool in_goal_range = false, bool in_kick_range = false);
 
   bool position_kick_distance(const keisan::Angle<double> & direction, keisan::Point2 distance,
     bool left_kick, bool center_kick);

--- a/src/suiryoku/locomotion/model/robot.cpp
+++ b/src/suiryoku/locomotion/model/robot.cpp
@@ -37,6 +37,16 @@ Robot::Robot()
 {
 }
 
+void Robot::set_orientation(const keisan::Point3 & orientation)
+{
+  this->prev_imu_roll = this->imu_roll;
+  this->prev_imu_pitch = this->imu_pitch;
+
+  this->imu_roll = keisan::make_degree(orientation.x);
+  this->imu_pitch = keisan::make_degree(orientation.y);
+  this->orientation = keisan::make_degree(orientation.z);
+}
+
 keisan::Angle<double> Robot::get_pan() const
 {
   return pan + pan_center;

--- a/src/suiryoku/locomotion/process/locomotion.cpp
+++ b/src/suiryoku/locomotion/process/locomotion.cpp
@@ -817,7 +817,7 @@ bool Locomotion::move_skew(const keisan::Angle<double> & direction, bool skew_le
   }
 }
 
-bool Locomotion::dribble(const keisan::Angle<double> & direction)
+bool Locomotion::dribble(const keisan::Angle<double> & direction, bool in_dribble_range)
 {
   double min_kick_tilt = std::min(left_kick_target_tilt.degree(), right_kick_target_tilt.degree());
   bool is_dribble = (robot->get_tilt() + robot->tilt_center).degree() <= min_kick_tilt;
@@ -834,7 +834,7 @@ bool Locomotion::dribble(const keisan::Angle<double> & direction)
   double pan_range_ratio = keisan::map(tilt, max_tilt + 10.0, max_tilt, 0.0, 0.4);
 
   double x_speed = 0;
-  if (std::abs(pan) < pan_range) {
+  if (std::abs(pan) < pan_range || in_dribble_range) {
     x_speed =
       keisan::map(std::abs(pan), pan_range_ratio * pan_range, pan_range, dribble_max_x, 0.0);
   } else {
@@ -844,10 +844,10 @@ bool Locomotion::dribble(const keisan::Angle<double> & direction)
 
   // y movement
   double y_speed = 0.0;
-  if (pan < -(pan_range) + (pan_range_ratio * pan_range)) {
-    y_speed = keisan::map(pan, -(pan_range), -6.0, dribble_max_ry, dribble_min_ry);
-  } else if (pan > pan_range - (pan_range_ratio * pan_range)) {
-    y_speed = keisan::map(pan, 6.0, pan_range, dribble_min_ly, dribble_max_ly);
+  if (pan < -3.0) {
+    y_speed = keisan::map(pan, -15.0, 0.0, dribble_max_ry, dribble_min_ry);
+  } else if (pan > 3.0) {
+    y_speed = keisan::map(pan, 0.0, 15.0, dribble_min_ly, dribble_max_ly);
   }
 
   // a movement
@@ -1113,7 +1113,7 @@ bool Locomotion::position_kick_custom_pan_tilt(
 
 bool Locomotion::position_kick_range_pan_tilt(
   const keisan::Angle<double> & direction, bool precise_kick, bool left_kick,
-  bool is_positioning_center)
+  bool is_positioning_center, bool in_goal_range, bool in_kick_range)
 {
   auto tilt = robot->get_tilt();
   auto pan = robot->get_pan();
@@ -1126,7 +1126,7 @@ bool Locomotion::position_kick_range_pan_tilt(
                                    : (right_kick_in_range || left_kick_in_range);
   bool direction_in_range = std::fabs(delta_direction) < position_min_delta_direction.degree();
 
-  if (tilt_in_range && pan_in_range && direction_in_range) {
+  if ((tilt_in_range && pan_in_range || in_kick_range) && (direction_in_range || in_goal_range)) {
     return true;
   }
 
@@ -1394,7 +1394,7 @@ int Locomotion::closer_to_which_kick_distance(keisan::Point2 ball_distance, bool
   double delta_right = (ball_distance - right_kick_distance).magnitude();
   double delta_left_center = std::numeric_limits<double>::infinity();
   double delta_right_center = std::numeric_limits<double>::infinity();
-  
+
   if (include_center) {
     delta_left_center = (ball_distance - left_kick_center_distance).magnitude();
     delta_right_center = (ball_distance - right_kick_center_distance).magnitude();


### PR DESCRIPTION
## Jira Link: 

## Description

Store previous robot IMU to stabilize the robot before kicking after positioning.
Refine dribble logic

## Type of Change

- [ ] Bugfix
- [x] Enhancement
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause the existing functionality to not work as expected)

## How Has This Been Tested?

- [ ] New unit tests added.
- [ ] Manual tested.

## Checklist:

- [ ] Using Branch Name Convention
    - `feature/JIRA-ID-SHORT-DESCRIPTION` if has a JIRA ticket
    - `enhancement/SHORT-DESCRIPTION` if has/has no JIRA ticket and contain enhancement
    - `hotfix/SHORT-DESCRIPTION` if the change doesn't need to be tested (urgent)
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made the documentation for the corresponding changes.